### PR TITLE
Fix initialization Philips TV settings form.

### DIFF
--- a/Auto3D-Philips/Connection/JointSpaceBaseAdapter.cs
+++ b/Auto3D-Philips/Connection/JointSpaceBaseAdapter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Net;
-using System.Text;
 using System.Threading;
 using System.Windows.Forms;
 using MediaPortal.GUI.Library;
@@ -13,7 +12,7 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 	{
 		protected string Host { get; set; }
 
-		private const string ContentType = "application/json; charset=UTF-8"; 
+		private const string ContentType = "application/json"; 
 
 		public virtual bool SendCommand(string command)
 		{
@@ -27,6 +26,7 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 
 		public virtual SystemBase TestConnection(string host)
 		{
+                        Host = host;
 			return null;
 		}
 
@@ -63,7 +63,7 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 				request.ContentType = ContentType;
 				request.Method = "POST";
 
-				var jsonString = JsonConvert.SerializeObject(key, Formatting.Indented);
+				var jsonString = JsonConvert.SerializeObject(key, Formatting.None);
 				Log.Debug("Auto3D: JSON-String = \"" + jsonString + "\"");
 
 				using (var streamWriter = new StreamWriter(request.GetRequestStream()))
@@ -99,7 +99,7 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 
 		protected string GetRequest(string url, string jsonString)
 		{
-			string result = string.Empty;			
+			string result;			
 			
 			try
 			{

--- a/Auto3D-Philips/Connection/JointSpaceV1Adapter.cs
+++ b/Auto3D-Philips/Connection/JointSpaceV1Adapter.cs
@@ -1,13 +1,12 @@
 ﻿using MediaPortal.GUI.Library;
 using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 {
 	public class JointSpaceV1Adapter : JointSpaceBaseAdapter
 	{
-		private static readonly Dictionary<string, string> _keys = new Dictionary<string, string>
+		private static readonly Dictionary<string, string> Keys = new Dictionary<string, string>
                                                                        {
                                                                            { "Home", "Home" },
                                                                            { "Adjust", "Adjust" },
@@ -26,7 +25,7 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 		{
 			string key;
 			
-			if (_keys.TryGetValue(command, out key))
+			if (Keys.TryGetValue(command, out key))
 			{
 				return base.SendCommand(key);
 			}
@@ -38,13 +37,9 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 			return false;
 		}
 
-		public override void Connect(string host)
-		{
-			base.Connect(host);			
-		}
-
 		public override SystemBase TestConnection(string host)
 		{
+		        base.TestConnection(host);
 			return JsonConvert.DeserializeObject<JointSpaceV1System>(GetRequest(SystemUri, string.Empty));
 		}
 

--- a/Auto3D-Philips/Connection/JointSpaceV5Adapter.cs
+++ b/Auto3D-Philips/Connection/JointSpaceV5Adapter.cs
@@ -6,7 +6,7 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 {
 	public class JointSpaceV5Adapter : JointSpaceBaseAdapter
 	{
-		private static readonly Dictionary<string, string> _keys = new Dictionary<string, string>
+		private static readonly Dictionary<string, string> Keys = new Dictionary<string, string>
                                                                        {
                                                                            { "Home", "Home" },
                                                                            { "Adjust", "Adjust" },
@@ -26,7 +26,7 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 		{
 			string key;
 			
-			if (_keys.TryGetValue(command, out key))
+			if (Keys.TryGetValue(command, out key))
 			{
 				return base.SendCommand(key);
 			}
@@ -38,13 +38,9 @@ namespace MediaPortal.ProcessPlugins.Auto3D.Devices
 			return false;
 		}
 
-		public override void Connect(string host)
-		{
-			base.Connect(host);			
-		}
-
 		public override SystemBase TestConnection(string host)
 		{
+                        base.TestConnection(host);
 			return JsonConvert.DeserializeObject<JointSpaceV5System>(GetRequest(SystemUri, string.Empty));
 		}
 


### PR DESCRIPTION
The _currentAdapter will set to JointSpaceV1Adapter only if it was not initialized in the LoadSettings() method.
Fix TestConnection() method. Early the Host property has not been initialized before call GetRequest() method. So, there was invalid URI.
On UI testing TV is async now.
@UnlimitedStack 
